### PR TITLE
Add Jetty static server for RestProxyStressTest downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ hs_err_pid*
 .idea
 *.iml
 .DS_Store
+**/temp/
 
 #eclipse
 .project

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -137,6 +137,21 @@
 <br />*/</code>]]></bottom>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.3.22.v20171030</version>
+        <configuration>
+          <httpConnector>
+            <port>11081</port>
+          </httpConnector>
+          <webApp>
+            <contextPath>/javasdktest/upload</contextPath>
+          </webApp>
+          <webAppSourceDirectory>temp/</webAppSourceDirectory>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.Scheduler;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.LoggerFactory;
@@ -639,9 +640,9 @@ public final class NettyClient extends HttpClient {
                 // Prevents channel from being closed when the Single<HttpResponse> is disposed
                 didEmitHttpResponse = true;
 
-                //Scheduler scheduler = Schedulers.from(ctx.channel().eventLoop());
+                Scheduler scheduler = Schedulers.from(ctx.channel().eventLoop());
                 responseEmitter.onSuccess(
-                        new NettyResponse(response, contentEmitter));
+                        new NettyResponse(response, contentEmitter.subscribeOn(scheduler, false)));
             }
 
             if (msg instanceof HttpContent) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -111,6 +111,7 @@ public final class FlowableUtil {
 
                     @Override
                     public void onSubscribe(Subscription s) {
+                        emitter.setCancellable(s::cancel);
                         subscription = s;
                         s.request(1);
                     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -17,9 +17,11 @@ import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.http.ContentType;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpPipeline;
+import com.microsoft.rest.v2.http.HttpPipelineBuilder;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.policy.AddHeadersPolicyFactory;
+import com.microsoft.rest.v2.policy.HostPolicyFactory;
 import com.microsoft.rest.v2.policy.HttpLogDetailLevel;
 import com.microsoft.rest.v2.policy.HttpLoggingPolicyFactory;
 import com.microsoft.rest.v2.policy.RequestPolicy;
@@ -34,6 +36,7 @@ import io.reactivex.SingleSource;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -68,6 +71,26 @@ import static org.junit.Assert.assertArrayEquals;
 
 @Ignore("Should only be run manually")
 public class RestProxyStressTests {
+    private static IOService service;
+
+    @BeforeClass
+    public static void setup() {
+        HttpHeaders headers = new HttpHeaders()
+                .set("x-ms-version", "2017-04-17");
+        HttpPipelineBuilder builder = new HttpPipelineBuilder()
+                .withRequestPolicy(new AddDatePolicyFactory())
+                .withRequestPolicy(new AddHeadersPolicyFactory(headers))
+                .withRequestPolicy(new ThrottlingRetryPolicyFactory());
+
+        String liveStressTests = System.getenv("JAVA_SDK_TEST_SAS");
+        if (liveStressTests == null || liveStressTests.isEmpty()) {
+            builder.withRequestPolicy(new HostPolicyFactory("http://localhost:11081"));
+        }
+
+        builder.withHttpLoggingPolicy(HttpLogDetailLevel.BASIC);
+
+        service = RestProxy.create(IOService.class, builder.build());
+    }
 
     private static final class AddDatePolicyFactory implements RequestPolicyFactory {
         @Override
@@ -233,17 +256,6 @@ public class RestProxyStressTests {
     @Test
     public void upload100MParallelTest() throws Exception {
         final String sas = System.getenv("JAVA_SDK_TEST_SAS");
-        HttpHeaders headers = new HttpHeaders()
-                .set("x-ms-version", "2017-04-17");
-
-        HttpPipeline pipeline = HttpPipeline.build(
-                new AddDatePolicyFactory(),
-                new AddHeadersPolicyFactory(headers),
-                new ThrottlingRetryPolicyFactory(),
-                new HttpLoggingPolicyFactory(HttpLogDetailLevel.BASIC));
-
-        final IOService service = RestProxy.create(IOService.class, pipeline);
-
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
                 .map(integer -> {
                     final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
@@ -308,17 +320,7 @@ public class RestProxyStressTests {
      */
     @Test
     public void download100MParallelTest() throws Exception {
-        final String sas = System.getenv("JAVA_SDK_TEST_SAS");
-        HttpHeaders headers = new HttpHeaders()
-                .set("x-ms-version", "2017-04-17");
-
-        HttpPipeline pipeline = HttpPipeline.build(
-                new AddDatePolicyFactory(),
-                new AddHeadersPolicyFactory(headers),
-                new ThrottlingRetryPolicyFactory(),
-                new HttpLoggingPolicyFactory(HttpLogDetailLevel.BASIC));
-
-        final IOService service = RestProxy.create(IOService.class, pipeline);
+        final String sas = System.getenv("JAVA_SDK_TEST_SAS") == null ? "" : System.getenv("JAVA_SDK_TEST_SAS");
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
                 .map(integer -> {
@@ -333,7 +335,7 @@ public class RestProxyStressTests {
                             final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
                             Flowable<ByteBuffer> content = response.body().doOnNext(messageDigest::update);
 
-                            AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.WRITE);
+                            AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + "-dl.dat"), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
                             return FlowableUtil.writeFile(content, file).doOnComplete(() -> {
                                 assertArrayEquals(md5, messageDigest.digest());
                                 LoggerFactory.getLogger(getClass()).info("Finished downloading and MD5 validated for " + id);


### PR DESCRIPTION
This will enable you to run a parallel download stress test without an Azure storage account or having to configure proxies or whatnot.

1. Run `mvn jetty:run -pl client-runtime` from the repo root, and leave it running
2. Run `RestProxyStressTests.prepare100MFiles()` **once** which will write 100x100MB files of random data to disk. (hopefully this isn't too inconvenient..)
3. Run `RestProxyStressTests.download100MParallelTest()` which will download the 100x100MB files from the static Jetty server in parallel and check the MD5s for consistency.

When this commit is applied directly to `v2` branch I found that it is able to get through the download in a reasonable amount of time, but in the `netty-client-rework` branch I see it start to hang after a bit.

The process of running this could probably be better streamlined, but that'll be part of a larger effort to have the stress tests run regularly in some CI environment that can handle the load gracefully.